### PR TITLE
[bugfix] drain response receiver after sending

### DIFF
--- a/tracing-honeycomb/src/honeycomb.rs
+++ b/tracing-honeycomb/src/honeycomb.rs
@@ -48,6 +48,8 @@ impl HoneycombTelemetry {
             // TODO: figure out strategy for handling this (eg report data loss event)
             eprintln!("error sending event to honeycomb, {:?}", err);
         }
+
+        while client.responses().try_recv().is_ok() {}
     }
 
     fn should_report(&self, trace_id: &TraceId) -> bool {


### PR DESCRIPTION
@rasviitanen @fooware What do you think about this solution? It will drain any waiting responses after sending an event. It should be fairly fast and distribute the "job" of draining the responses farirly evenly.